### PR TITLE
Remove duplicated code, replaced with UpdateCRC. Funtion SlurpBlock.

### DIFF
--- a/CommonSrc/CRC32.cs
+++ b/CommonSrc/CRC32.cs
@@ -150,16 +150,7 @@ namespace Ionic.Crc
             {
                 int x = offset + i;
                 byte b = block[x];
-                if (this.reverseBits)
-                {
-                    UInt32 temp = (_register >> 24) ^ b;
-                    _register = (_register << 8) ^ crc32Table[temp];
-                }
-                else
-                {
-                    UInt32 temp = (_register & 0x000000FF) ^ b;
-                    _register = (_register >> 8) ^ crc32Table[temp];
-                }
+                UpdateCRC(b);
             }
             _TotalBytesRead += count;
         }


### PR DESCRIPTION
Removed duplicated lines of code.
Replaced with `UpdateCRC`.

```csharp
public void SlurpBlock(byte[] block, int offset, int count)
{
    if (block == null)
        throw new Exception("The data buffer must not be null.");

    // bzip algorithm
    for (int i = 0; i < count; i++)
    {
        int x = offset + i;
        byte b = block[x];
        if (this.reverseBits)
        {
            UInt32 temp = (_register >> 24) ^ b;
            _register = (_register << 8) ^ crc32Table[temp];
        }
        else
        {
            UInt32 temp = (_register & 0x000000FF) ^ b;
            _register = (_register >> 8) ^ crc32Table[temp];
        }
    }
    _TotalBytesRead += count;
}
```
Replaces with:
```csharp
public void SlurpBlock(byte[] block, int offset, int count)
{
    if (block == null)
        throw new Exception("The data buffer must not be null.");

    // bzip algorithm
    for (int i = 0; i < count; i++)
    {
        int x = offset + i;
        byte b = block[x];
        UpdateCRC(b);
    }
    _TotalBytesRead += count;
}
```

Because `UpdateCRC` has:
```csharp
public void UpdateCRC(byte b)
{
    if (this.reverseBits)
    {
        UInt32 temp = (_register >> 24) ^ b;
        _register = (_register << 8) ^ crc32Table[temp];
    }
    else
    {
        UInt32 temp = (_register & 0x000000FF) ^ b;
        _register = (_register >> 8) ^ crc32Table[temp];
    }
}
```